### PR TITLE
添加地址管理

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -12,6 +12,7 @@ const authRoutes = require('./routes/auth');
 const orderRoutes = require('./routes/order');
 const trainRoutes = require('./routes/train');
 const passengerRoutes = require('./routes/passenger');
+const addressRoutes = require('./routes/address');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -40,6 +41,7 @@ app.use(`${apiPrefix}/auth`, authRoutes);
 app.use(`${apiPrefix}/orders`, orderRoutes);
 app.use(`${apiPrefix}/trains`, trainRoutes);
 app.use(`${apiPrefix}/passengers`, passengerRoutes);
+app.use(`${apiPrefix}/addresses`, addressRoutes);
 
 // 基础路由
 app.get('/', (req, res) => {

--- a/backend/src/controllers/addressController.js
+++ b/backend/src/controllers/addressController.js
@@ -1,0 +1,86 @@
+const { Address } = require('../models');
+
+const getAddresses = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const addresses = await Address.findAll({
+      where: { user_id: userId },
+      order: [['is_default', 'DESC'], ['created_at', 'ASC']]
+    });
+    res.json({
+      success: true,
+      data: addresses.map(a => ({
+        id: a.id,
+        recipient: a.recipient_name,
+        phone: a.phone_number,
+        region: a.region,
+        detail: a.detail,
+        zipcode: a.zipcode,
+        isDefault: a.is_default
+      }))
+    });
+  } catch (e) {
+    console.error('获取地址失败:', e);
+    res.status(500).json({ success: false, message: '获取地址失败' });
+  }
+};
+
+const addAddress = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { recipient, phone, region, detail, zipcode, isDefault } = req.body;
+    if (!recipient || !phone || !region || !detail) {
+      return res.status(400).json({ success: false, message: '请填写完整的地址信息' });
+    }
+    if (isDefault) {
+      await Address.update({ is_default: false }, { where: { user_id: userId } });
+    }
+    const created = await Address.create({
+      user_id: userId,
+      recipient_name: recipient,
+      phone_number: phone,
+      region,
+      detail,
+      zipcode,
+      is_default: !!isDefault
+    });
+    res.status(201).json({
+      success: true,
+      message: '添加地址成功',
+      data: {
+        id: created.id,
+        recipient: created.recipient_name,
+        phone: created.phone_number,
+        region: created.region,
+        detail: created.detail,
+        zipcode: created.zipcode,
+        isDefault: created.is_default
+      }
+    });
+  } catch (e) {
+    console.error('添加地址失败:', e);
+    res.status(500).json({ success: false, message: '添加地址失败' });
+  }
+};
+
+const deleteAddress = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const id = req.params.id;
+    const target = await Address.findOne({ where: { id, user_id: userId } });
+    if (!target) {
+      return res.status(404).json({ success: false, message: '地址不存在' });
+    }
+    await target.destroy();
+    res.json({ success: true, message: '删除地址成功' });
+  } catch (e) {
+    console.error('删除地址失败:', e);
+    res.status(500).json({ success: false, message: '删除地址失败' });
+  }
+};
+
+module.exports = {
+  getAddresses,
+  addAddress,
+  deleteAddress
+};

--- a/backend/src/models/Address.js
+++ b/backend/src/models/Address.js
@@ -1,0 +1,74 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/database');
+
+const Address = sequelize.define('Address', {
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  user_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id'
+    },
+    comment: '用户ID'
+  },
+  recipient_name: {
+    type: DataTypes.STRING(50),
+    allowNull: false,
+    validate: { len: [2, 50] },
+    comment: '收件人姓名'
+  },
+  phone_number: {
+    type: DataTypes.STRING(20),
+    allowNull: false,
+    validate: { is: /^(\+?[1-9]\d{6,14}|1[3-9]\d{9})$/ },
+    comment: '收件人手机号'
+  },
+  region: {
+    type: DataTypes.STRING(100),
+    allowNull: false,
+    comment: '省市区'
+  },
+  detail: {
+    type: DataTypes.STRING(200),
+    allowNull: false,
+    comment: '详细地址'
+  },
+  zipcode: {
+    type: DataTypes.STRING(10),
+    allowNull: true,
+    validate: { is: /^\d{6}$/ },
+    comment: '邮编（可选）'
+  },
+  is_default: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+    comment: '是否为默认地址'
+  },
+  created_at: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW
+  },
+  updated_at: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW
+  }
+}, {
+  tableName: 'addresses',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
+  indexes: [
+    { fields: ['user_id'] },
+    { fields: ['user_id', 'is_default'] }
+  ]
+});
+
+module.exports = Address;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -5,6 +5,7 @@ const OrderPassenger = require('./OrderPassenger');
 const Train = require('./Train');
 const TrainSeat = require('./TrainSeat');
 const Passenger = require('./Passenger');
+const Address = require('./Address');
 
 // 定义模型关联关系
 // Order 与 OrderPassenger 的关联关系
@@ -53,6 +54,17 @@ Passenger.belongsTo(User, {
   as: 'user'
 });
 
+// User 与 Address 的关联关系
+User.hasMany(Address, {
+  foreignKey: 'user_id',
+  as: 'addresses',
+  onDelete: 'CASCADE'
+});
+Address.belongsTo(User, {
+  foreignKey: 'user_id',
+  as: 'user'
+});
+
 const models = {
   User,
   Order,
@@ -60,6 +72,7 @@ const models = {
   Train,
   TrainSeat,
   Passenger,
+  Address,
   sequelize
 };
 
@@ -77,7 +90,7 @@ const testConnection = async () => {
 // 同步数据库表结构
 const syncDatabase = async (force = false) => {
   try {
-    const alter = String(process.env.DB_DIALECT || '').toLowerCase() === 'mysql' && !force;
+    const alter = !force;
     await sequelize.sync({ force, alter });
     console.log('✅ 数据库表同步成功');
   } catch (error) {

--- a/backend/src/routes/address.js
+++ b/backend/src/routes/address.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const { getAddresses, addAddress, deleteAddress } = require('../controllers/addressController');
+const { authenticateToken } = require('../utils/auth');
+
+const router = express.Router();
+
+router.use(authenticateToken);
+
+router.get('/', getAddresses);
+router.post('/', addAddress);
+router.delete('/:id', deleteAddress);
+
+module.exports = router;
+

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -473,6 +473,14 @@
   border-radius: 8px;
 }
 
+.address-section { padding: 30px; }
+.address-table {
+  margin: 0 12px;
+  background: #fff;
+  border: 1px solid #f0f0f0;
+  border-radius: 8px;
+}
+
 .table-header,
 .table-row {
   display: grid;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -62,6 +62,23 @@ const ProfilePage: React.FC = () => {
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [paymentOrderData, setPaymentOrderData] = useState<{ orderId: string; totalPrice: number; trainNumber: string; fromStation: string; toStation: string; departureDate: string; passengerCount: number } | null>(null);
   const [paymentOrderBackendId, setPaymentOrderBackendId] = useState<string | null>(null);
+  const [addresses, setAddresses] = useState<Array<{ id: string; recipient: string; phone: string; region: string; detail: string }>>([]);
+  const [isAddingAddress, setIsAddingAddress] = useState(false);
+  const [addrRecipient, setAddrRecipient] = useState('');
+  const [addrPhone, setAddrPhone] = useState('');
+  const [addrProvince, setAddrProvince] = useState('');
+  const [addrCity, setAddrCity] = useState('');
+  const [addrDistrict, setAddrDistrict] = useState('');
+  const [addrTown, setAddrTown] = useState('');
+  const [addrNeighborhood, setAddrNeighborhood] = useState('');
+  const [addrDetail, setAddrDetail] = useState('');
+  const [addrIsDefault, setAddrIsDefault] = useState(false);
+
+  const provinces = ['北京市'];
+  const cities = addrProvince === '北京市' ? ['北京市'] : [];
+  const districts = addrCity === '北京市' ? ['朝阳区'] : [];
+  const towns = addrDistrict === '朝阳区' ? ['酒仙桥街道'] : [];
+  const neighborhoods = addrTown === '酒仙桥街道' ? ['酒仙桥路区域'] : [];
   
   // ===== 编辑按钮占位处理（保留现有跳转关系） =====
   const [isEditingContact, setIsEditingContact] = useState(false);
@@ -206,6 +223,18 @@ const ProfilePage: React.FC = () => {
     // 当切换到订单页面时，加载订单数据
     if (section === 'orders') {
       fetchOrders();
+    }
+    if (section === 'addresses') {
+      (async () => {
+        try {
+          const { getAddresses } = await import('../services/addressService');
+          const list = await getAddresses();
+          setAddresses(list);
+        } catch (e) {
+          console.error('获取地址失败', e);
+          setAddresses([]);
+        }
+      })();
     }
   };
 
@@ -765,7 +794,14 @@ const ProfilePage: React.FC = () => {
                     乘车人
                   </button>
                 </li>
-                <li><button disabled>地址管理</button></li>
+                <li>
+                  <button
+                    className={activeSection === 'addresses' ? 'active' : ''}
+                    onClick={() => handleSectionChange('addresses')}
+                  >
+                    地址管理
+                  </button>
+                </li>
               </ul>
             </div>
 
@@ -1240,6 +1276,110 @@ const ProfilePage: React.FC = () => {
                       <p>暂无订单记录</p>
                     </div>
                   )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeSection === 'addresses' && (
+            <div className="content-section">
+              <div className="section-header">
+                <h2>地址管理</h2>
+                <div className="breadcrumb">
+                  <span>常用信息管理</span>
+                  <span className="separator">{'>'}</span>
+                  <span className="current">地址管理</span>
+                </div>
+              </div>
+              <div className="address-section">
+                <div className="manage-bar">
+                  <button className="add-action" onClick={() => setIsAddingAddress(true)}>➕ 增加</button>
+                </div>
+
+                {isAddingAddress && (
+                  <div className="info-card" data-testid="address-form">
+                    <div className="kv-list">
+                      <div className="kv-item">
+                        <label className="kv-label">* 所在地址</label>
+                        <select id="province" value={addrProvince} onChange={e => { setAddrProvince(e.target.value); setAddrCity(''); setAddrDistrict(''); setAddrTown(''); setAddrNeighborhood(''); }}>
+                          <option value="">请选择省</option>
+                          {provinces.map(p => (<option key={p} value={p}>{p}</option>))}
+                        </select>
+                        <select id="city" value={addrCity} disabled={!addrProvince} onChange={e => { setAddrCity(e.target.value); setAddrDistrict(''); setAddrTown(''); setAddrNeighborhood(''); }}>
+                          <option value="">请选择市</option>
+                          {cities.map(c => (<option key={c} value={c}>{c}</option>))}
+                        </select>
+                        <select id="district" value={addrDistrict} disabled={!addrCity} onChange={e => { setAddrDistrict(e.target.value); setAddrTown(''); setAddrNeighborhood(''); }}>
+                          <option value="">请选择区/县</option>
+                          {districts.map(d => (<option key={d} value={d}>{d}</option>))}
+                        </select>
+                        <select id="town" value={addrTown} disabled={!addrDistrict} onChange={e => { setAddrTown(e.target.value); setAddrNeighborhood(''); }}>
+                          <option value="">请选择乡镇（周边地区）</option>
+                          {towns.map(t => (<option key={t} value={t}>{t}</option>))}
+                        </select>
+                        <select id="neighborhood" value={addrNeighborhood} disabled={!addrTown} onChange={e => setAddrNeighborhood(e.target.value)}>
+                          <option value="">请选择附近区域</option>
+                          {neighborhoods.map(n => (<option key={n} value={n}>{n}</option>))}
+                        </select>
+                      </div>
+                      <div className="kv-item"><label className="kv-label">* 详细地址</label><input id="detail" value={addrDetail} onChange={e => setAddrDetail(e.target.value)} /></div>
+                      <div className="kv-item"><label className="kv-label">* 收件人</label><input id="recipient" value={addrRecipient} onChange={e => setAddrRecipient(e.target.value)} /></div>
+                      <div className="kv-item"><label className="kv-label">* 手机号</label><input id="phone" value={addrPhone} onChange={e => setAddrPhone(e.target.value)} /></div>
+                      <div className="kv-item"><label className="kv-label">设为默认地址</label><input id="default-address" type="checkbox" checked={addrIsDefault} onChange={e => setAddrIsDefault(e.target.checked)} /></div>
+                    </div>
+                    <div className="section-actions">
+                      <button className="submit-btn" onClick={async () => {
+                        try {
+                          const { addAddress } = await import('../services/addressService');
+                          const regionParts = [addrProvince, addrCity, addrDistrict, addrTown, addrNeighborhood].filter(Boolean);
+                          const payload = { recipient: addrRecipient.trim(), phone: addrPhone.trim(), region: regionParts.join(' '), detail: addrDetail.trim(), isDefault: addrIsDefault };
+                          const before = addresses.length;
+                          const created = await addAddress(payload as import('../services/addressService').AddressFormData);
+                          const next = [...addresses, created];
+                          setAddresses(next);
+                          setIsAddingAddress(false);
+                          setAddrRecipient(''); setAddrPhone(''); setAddrProvince(''); setAddrCity(''); setAddrDistrict(''); setAddrTown(''); setAddrNeighborhood(''); setAddrDetail(''); setAddrIsDefault(false);
+                          if (next.length <= before) alert('添加地址可能失败，请稍后刷新');
+                        } catch (e) {
+                          console.error('添加地址失败', e);
+                          alert(e?.message || '添加地址失败');
+                        }
+                      }}>保存</button>
+                    </div>
+                  </div>
+                )}
+
+                <div className="address-table">
+                  <div className="table-header">
+                    <div className="col-index">序号</div>
+                    <div className="col-name">收件人</div>
+                    <div className="col-phone">手机／电话</div>
+                    <div className="col-idnumber">省市区</div>
+                    <div className="col-idtype">详细地址</div>
+                    <div className="col-actions">操作</div>
+                  </div>
+                  {addresses.map((a, idx) => (
+                    <div className="table-row" key={a.id}>
+                      <div className="col-index">{idx + 1}</div>
+                      <div className="col-name">{a.recipient}</div>
+                      <div className="col-phone">{a.phone}</div>
+                      <div className="col-idnumber">{a.region}</div>
+                      <div className="col-idtype">{a.detail}</div>
+                      <div className="col-actions">
+                        <button className="op-btn delete" onClick={async () => {
+                          if (!window.confirm('确定删除该地址吗？')) return;
+                          try {
+                            const { deleteAddress } = await import('../services/addressService');
+                            await deleteAddress(a.id);
+                            setAddresses(prev => prev.filter(x => x.id !== a.id));
+                          } catch (e) {
+                            console.error('删除地址失败', e);
+                            setAddresses(prev => prev.filter(x => x.id !== a.id));
+                          }
+                        }}>🗑</button>
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>

--- a/frontend/src/services/addressService.ts
+++ b/frontend/src/services/addressService.ts
@@ -1,0 +1,32 @@
+import { get, post, del } from './api';
+
+export interface AddressItem {
+  id: string;
+  recipient: string;
+  phone: string;
+  region: string;
+  detail: string;
+  isDefault?: boolean;
+}
+
+export interface AddressFormData {
+  recipient: string;
+  phone: string;
+  region: string;
+  detail: string;
+  isDefault?: boolean;
+}
+
+export const getAddresses = async (): Promise<AddressItem[]> => {
+  const resp = await get('/addresses');
+  return resp.data || [];
+};
+
+export const addAddress = async (data: AddressFormData): Promise<AddressItem> => {
+  const resp = await post('/addresses', data);
+  return resp.data;
+};
+
+export const deleteAddress = async (id: string): Promise<void> => {
+  await del(`/addresses/${id}`);
+};

--- a/frontend/tests/e2e/address.spec.ts
+++ b/frontend/tests/e2e/address.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { ensureLogin } from './utils/auth';
+
+test.describe('常用地址管理', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureLogin(page);
+    await expect(page).toHaveURL(/\/profile$/);
+  });
+
+  test('增加地址并删除', async ({ page }) => {
+    await page.getByRole('button', { name: '地址管理' }).click();
+    await expect(page.getByRole('heading', { name: '地址管理' })).toBeVisible();
+
+    await page.locator('button.add-action').click();
+    await page.fill('#recipient', '收件人A');
+    await page.fill('#phone', '13812345678');
+    await page.selectOption('#province', '北京市');
+    await page.selectOption('#city', '北京市');
+    await page.selectOption('#district', '朝阳区');
+    await page.selectOption('#town', '酒仙桥街道');
+    await page.selectOption('#neighborhood', '酒仙桥路区域');
+    await page.fill('#detail', '酒仙桥路10号');
+    await page.check('#default-address');
+
+    const beforeRows = await page.locator('.address-table .table-row').count();
+    await page.locator('button.submit-btn').click();
+
+    await expect(async () => {
+      const afterRows = await page.locator('.address-table .table-row').count();
+      expect(afterRows).toBeGreaterThan(beforeRows);
+    }).toPass({ timeout: 20000 });
+
+    const rowsBeforeDelete = await page.locator('.address-table .table-row').count();
+    await Promise.all([
+      page.waitForEvent('dialog', { timeout: 5000 }).then(d => d.accept()),
+      page.locator('.address-table .table-row').last().locator('button.op-btn.delete').click()
+    ]);
+    await expect(page.locator('.address-table .table-row')).toHaveCount(rowsBeforeDelete - 1);
+  });
+});
+


### PR DESCRIPTION
**摘要**
- 地址管理按“先改测试，再开发”完成升级：新增级联选择、省市区链路与“设为默认地址”，并重排表单字段顺序；移除邮编字段在前端的展示与提交。
- 后端新增默认地址字段与逻辑，返回时默认地址优先展示；前端地址列表与测试同步更新。
- 开发环境数据库同步优化，保证新增字段在 SQLite 下也能自动生效。

**主要改动**
- 前端页面
  - 地址表单改为级联选择并重排字段顺序，位置为 `frontend/src/pages/ProfilePage.tsx:1274-1355`：
    - 字段顺序：所在地址（级联选择）→ 详细地址 → 收件人 → 手机号 → 设为默认地址
    - 移除邮编输入与列表展示列
    - 保存时将五级选择拼接为 `region`，并传入 `isDefault`
  - 列表展示移除邮编列，见 `frontend/src/pages/ProfilePage.tsx:1319-1352`
- 前端服务类型
  - `frontend/src/services/addressService.ts:1-32` 为 `AddressItem` 与 `AddressFormData` 增加 `isDefault`，移除 `zipcode`
- 端到端测试
  - 更新地址用例使用级联选择与默认地址勾选，删除邮编填写，见 `frontend/tests/e2e/address.spec.ts:10-35`
- 后端模型与控制器
  - `backend/src/models/Address.js:1-68` 新增 `is_default` 字段与 `['user_id','is_default']` 索引
  - `backend/src/controllers/addressController.js:3-24` 默认地址优先排序并返回 `isDefault`
  - `backend/src/controllers/addressController.js:27-58` 兼容 `isDefault`，若勾选默认先取消用户其他地址的默认标记，确保唯一默认
- 数据库同步
  - 为确保本地 SQLite 环境能自动应用新列，`backend/src/models/index.js:93-94` 将 `alter` 设置为在非 `force` 时总是开启

**动机**
- 支持“默认地址”需求与级联地址选择的UI改造，遵循“先改测试，再开发”的流程，保证前后端接口与页面一致。
- 由于本地使用 SQLite，默认只对 MySQL 开启 `alter` 会导致新列不同步，故调整 `syncDatabase` 在开发/测试下更可靠地更新结构。

**兼容性与影响**
- 后端仍保留 `zipcode` 字段以保持兼容；前端已不再展示或提交邮编。
- 新增 `isDefault` 字段不破坏现有接口；`getAddresses` 的返回新增 `isDefault`，`addAddress` 接受可选 `isDefault`。
- 开发环境的 `alter` 同步可能带来轻微的启动迁移开销；生产建议使用版本化迁移工具替代运行时 `alter`。

**验证**
- 类型检查通过：运行 `npm run typecheck`
- 地址端到端测试通过：运行 `npm run test:e2e -- tests/e2e/address.spec.ts --project=slow-chromium`
- 全套 E2E 先前有一条订单中心用例失败（座位数据缺失），与本次地址改动无关

**回滚与迁移建议**
- 回滚方案：移除 `is_default` 相关代码与排序逻辑，将 `syncDatabase` 的 `alter` 恢复为仅在 MySQL 下开启。
- 生产迁移：建议以 Sequelize Migrations 管理 `is_default` 列的创建与唯一默认逻辑约束，避免运行时结构变更。