### PR TITLE
重构订单列表，展示车票票价

### DIFF
--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -917,23 +917,116 @@
   box-shadow: 0 0 0 2px rgba(226, 66, 43, 0.2);
 }
 
-.orders-table { display: grid; gap: 12px; margin-top: 8px; width: 100%; min-width: 0; }
-.orders-table-header, .orders-table-row { display: grid; grid-template-columns: 1fr 1fr 1fr 120px 120px; align-items: center; }
-.orders-table-header { background: #f8f8f8; color: #555; height: 40px; padding: 0 12px; font-size: 15px; border: 1px solid #f0f0f0; border-radius: 0; align-items: center; box-sizing: border-box; width: 100%; }
+.orders-table { display: flex; flex-direction: column; gap: 12px; margin-top: 8px; width: 100%; min-width: 0; }
+.orders-table-header { display: flex; align-items: stretch; border-bottom: 1px solid #f0f0f0; background: #fafafa; }
+.orders-table-header > div { flex: 1; text-align: center; padding: 12px; color: #666; font-size: 14px; }
+.orders-table-header > div:nth-child(1) { flex: 0.8; }
+.orders-table-header > div:nth-child(2) { flex: 1; }
+.orders-table-header > div:nth-child(3) { flex: 1; }
+.orders-table-header > div:nth-child(4) { flex: 1; }
+.orders-table-header > div:nth-child(5) { flex: 1; }
+
 .orders-table-item { border: 1px solid #e6f0fc; border-radius: 6px; background: #fff; }
 .order-meta { background: #e6f4ff; color: #666; font-size: 14px; padding: 0 12px; height: 40px; border-bottom: 1px solid #f0f0f0; display: flex; align-items: center; gap: 12px; box-sizing: border-box; width: 100%; }
 .toggle-btn { width: 20px; height: 20px; border: 1px solid #dcdcdc; border-radius: 4px; background: #fff; color: #666; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; padding: 0; }
 .order-meta .meta-sep { margin-left: 12px; }
-.orders-table-row { height: auto; padding: 8px 12px; font-size: 14px; }
-.train-col .train-route { font-weight: 600; color: #333; font-size: 16px;}
-.train-col .train-no { color: #4a90e2; font-weight: 600; margin-left: 6px; }
+
+.orders-table-row {
+  display: flex;
+  min-height: 80px;
+  align-items: stretch;
+  border-top: 1px solid #e0e0e0;
+}
+
+.train-col {
+  flex: 0.8;
+  padding: 15px 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-right: 1px solid #f0f0f0;
+}
+
+.train-col .train-route { font-weight: 600; color: #333; font-size: 16px; margin-bottom: 5px; }
+.train-col .train-number { font-weight: 600; color: #333; font-size: 16px; }
 .train-col .train-time { color: #666; font-size: 12px; }
-.passenger-col .passenger-name { font-weight: 500; color: #333; font-size: 14px; display: inline-block; }
-.passenger-col .id-type { color: #666; font-size: 12px; }
-.link-btn.small { border: none; background: none; color: #1677ff; cursor: pointer; font-size: 12px; padding: 0; margin-left: 8px; }
-.seat-col div:first-child { font-weight: 500; font-size: 14px; align-items: center;}
-.price-col .price-val { color: #de8920; font-weight: 400; }
-.status-col { display: flex; align-items: center; gap: 8px; }
+
+.passengers-group-col {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+}
+
+.passenger-row-item {
+  display: flex;
+  border-bottom: 1px solid #f0f0f0;
+  flex: 1;
+}
+.passenger-row-item:last-child {
+  border-bottom: none;
+}
+
+.passenger-col {
+  flex: 1;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-right: 1px solid #f0f0f0;
+}
+
+.passenger-col .passenger-name {
+  font-size: 16px;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.passenger-col .id-type {
+  font-size: 12px;
+  color: #666;
+}
+
+.seat-col {
+  flex: 1;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #333;
+  border-right: 1px solid #f0f0f0;
+}
+
+.price-col {
+  flex: 1;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #E2422B;
+  font-weight: 500;
+  border-right: 1px solid #f0f0f0;
+}
+
+.price-col .price-val {
+  font-size: 16px;
+  font-weight: bold;
+  color: #FF8001;
+  margin-top: 4px;
+}
+
+.status-col {
+  flex: 1;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
 .ticket-status.paid { color: #2f8f3b; }
 .ticket-status.unpaid { color: #fa8c16; }
 .ticket-status.completed { color: #1677ff; }

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -153,7 +153,7 @@ export interface FormattedOrder {
   tripDate?: string;
   passenger: string;
   seat: string;
-  passengers?: Array<{ name: string; seatNumber?: string; seatType?: string; carriage?: string | number }>;
+  passengers?: Array<{ name: string; seatNumber?: string; seatType?: string; carriage?: string | number; price?: number }>;
   price: number;
   status: 'paid' | 'unpaid' | 'cancelled' | 'refunded' | 'completed' | 'changed';
 }
@@ -177,7 +177,7 @@ export const fetchUserOrdersFormatted = async (page = 1, limit = 10, status?: st
       orderDate?: string;
       bookDate?: string;
       createdAt?: unknown;
-      passengers?: Array<{ passengerName?: string; name?: string; seatNumber?: string; seatType?: string; carriage?: string | number }>;
+      passengers?: Array<{ passengerName?: string; name?: string; seatNumber?: string; seatType?: string; carriage?: string | number; price?: number }>;
       seat?: string;
       totalPrice?: number;
       price?: number;
@@ -203,6 +203,7 @@ export const fetchUserOrdersFormatted = async (page = 1, limit = 10, status?: st
             seatNumber: p.seatNumber,
             seatType: p.seatType,
             carriage: p.carriage,
+            price: Number(p.price || 0)
           }))
         : undefined,
       price: o.totalPrice ?? o.price ?? 0,


### PR DESCRIPTION
### 描述 (Description)
fix: #44 
本次 PR 主要重构了**个人中心-火车票**的 UI 展示逻辑，还原 12306 网站的经典布局风格，修复了多乘客订单的显示对其问题及价格显示异常。

### 解决了什么问题 (Motivation)
1.  **UI 布局不符合预期**：之前的实现中，如果一个订单包含多名乘客，订单仅仅会展示一位乘客信息；
2.  **价格显示错误**：在展示单个乘客信息时，价格栏错误地显示了整个订单的总价，而非单张车票的价格；
3.  **样式层级缺失**：缺乏 12306 典型的“左侧车次信息合并、中间乘客信息分行、右侧状态操作合并”的视觉层级。

### 解决方案 (Key Changes)

事实上，后端数据库结构非常扎实，有订单表：orders，用来记录整体的订单信息，支持订单整体的操作（支付、退票、是否出行等）；订单中的车票/乘客表order_passengers，用来记录订单中不同乘客不同座次的车票信息，包括价格。因此，只需要从需求的角度出发，在前端展示时，提示ai展示相应的数据即可，例如：
理解我当前的表结构，重点时orders、order_passengers表，
- 在订单列表项中，我需要分别展示每个车票的信息，包括旅客、座次、价格等；
- 在订单支付页，我需要展示订单整体的票价。

#### 1. 前端服务层 (orderService.ts)
*   更新了 `FormattedOrder` 和相关接口定义，为乘客对象显式增加了 `price` 字段。
*   在数据转换层添加了逻辑，优先提取后端返回的单客票价。

#### 2. UI 逻辑与交互 (ProfilePage.tsx)
*   **移除扁平化处理**：删除了 `fetchOrders` 中将订单按乘客拆分的 `flatMap` 逻辑，现在前端状态保持以“订单”为单位。
*   **嵌套渲染结构**：重写了 JSX 结构，现在一个订单卡片内部包含：
    *   **左侧 (Left)**：车次、出发到达信息（跨行显示，对应所有乘客）。
    *   **中间 (Middle)**：一个 `flex-column` 容器，遍历 `passengers` 数组渲染多行，每行包含姓名、证件、席位和单价。
    *   **右侧 (Right)**：订单状态和操作按钮（如“支付”、“退票”），统一对整个订单生效。
*   **价格回退逻辑**：渲染时优先使用 `passenger.price`，若缺失则通过 `totalPrice / passengerCount` 计算单价，确保金额准确。

### 效果预览
- 未完成订单选项卡，展示订单中包含的车票信息，订单操作（如“去支付”）仍然为一个整体：
![1](https://github.com/user-attachments/assets/986a26e0-a2e5-4f71-a99a-d8e0648ed889)

- 未出行订单选项卡，同理：
![3](https://github.com/user-attachments/assets/b10668c6-03ab-429b-a32c-e731c776981d)

- 订单支付界面，需要展示总票价：
![2](https://github.com/user-attachments/assets/af18f314-1f19-4069-998c-2c0a88a9460e)

